### PR TITLE
Fix content overlap

### DIFF
--- a/src/views/404/NotFound.module.scss
+++ b/src/views/404/NotFound.module.scss
@@ -5,19 +5,13 @@
 
     /* center vertically */
 
-    height: 100%;
+    height: fit-content;
     margin: auto;
     position: absolute;
     top: 0; 
     left: 0; 
     bottom: 0; 
     right: 0;
-
-    /* center children */
-
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
 
     /* prevent galaxy background elements from overlapping the error message */
 


### PR DESCRIPTION
The error message container was overlapping the navbar causing it to be unusable