### PR TITLE
Fix LocationMap component

### DIFF
--- a/src/components/ui/LocationMap/LocationMap.module.scss
+++ b/src/components/ui/LocationMap/LocationMap.module.scss
@@ -6,20 +6,20 @@
 
     background-color: #fff;
     border-radius: var(--border-radius);
-    max-width: 16.5625rem;
-    min-height: 17.5rem;
+    width: 265px;
+    min-height: 280px;
 
     display: flex;
     flex-direction: column;
 
     .mapCardTitle {
         font-weight: 800;
-        font-size: 1.125rem;
-        margin-bottom: .625rem;
+        font-size: 18px;
+        margin-bottom: 10px;
     }
 
     .mapCardAddress {
-        margin-bottom: .375rem;
+        margin-bottom: 6px;
     }
 
 }

--- a/src/components/ui/LocationMap/LocationMap.stories.mdx
+++ b/src/components/ui/LocationMap/LocationMap.stories.mdx
@@ -38,3 +38,19 @@ For some reason the marker icon doesn't work in the Storybook preview.
         {Template.bind({})}
     </Story>
 </Canvas>
+
+<Canvas style={{background: "silver"}}>
+    <Story
+        name="With a very long address"
+        parameters={{
+            layout: 'centered',
+        }}
+        args={{
+            latitude: 51.107835874093816,
+            longitude: 17.03858762148716,
+            address: 'Dłuuuuuuuuuuuuuuuuuuuuuuga 2/4, 53-146 Wrocław'
+        }}
+    >
+        {Template.bind({})}
+    </Story>
+</Canvas>


### PR DESCRIPTION
Fixed LocationMap not displaying properly when not provided an address, changed rem units to px in the css and added a new storybook variant for a very long address